### PR TITLE
Workaround, libsass does not correctly interpolate here.

### DIFF
--- a/lib/compass/typography/_vertical_rhythm.scss
+++ b/lib/compass/typography/_vertical_rhythm.scss
@@ -180,10 +180,8 @@ $base-half-leader: $base-leader / 2;
   @if not($relative-font-sizing) and $font-size != $base-font-size {
     @warn "$relative-font-sizing is false but a relative font size was passed to apply-side-rhythm-border";
   }
-  border-#{$side}: {
-    style: $border-style;
-    width: $font-unit * $width / $font-size;
-  };
+  border-#{$side}-style: $border-style;
+  border-#{$side}-width: $font-unit * $width / $font-size;
   padding-#{$side}: rhythm($lines, $font-size, $offset: $width);
 }
 


### PR DESCRIPTION
Had to make this change in order to compile with libsass correctly. Something with string interpolation here was causing the output CSS to not contain the interpolated value of $side, and instead just looked like

```
border-$side-style: /*etc*/
```

No hard feelings if you don't want to merge this one, it's not a bug in your sass sheets, this is just a workaround for current libsass users until the interpolation of libsass is brought up to parity.