### PR TITLE
Added explicit reference to functions file

### DIFF
--- a/lib/compass/css3/_images.scss
+++ b/lib/compass/css3/_images.scss
@@ -1,5 +1,6 @@
 @import "shared";
 @import "../utilities/general/hacks";
+@import "../functions";
 
 // Background property support for vendor prefixing within values.
 @mixin background(


### PR DESCRIPTION
I was getting this error with libsass. Explicit reference to the compass functions is needed. 

>> may only compare numbers
>>   Line 19  Column 14  lib/compass-mixins/lib/compass/css3/_images.scss