### PR TITLE
address bug with sass file reference

### DIFF
--- a/lib/_animate.scss
+++ b/lib/_animate.scss
@@ -1,1 +1,1 @@
-@import "animation";
+@import "animation/animate";


### PR DESCRIPTION
When using this lib there was a fail where the Sass being referenced didn't exist. Making this update patches the path correctly and removes the bug. 