### PR TITLE
import functions.scss in files that use compact() function

### DIFF
--- a/lib/compass/css3/_box-shadow.scss
+++ b/lib/compass/css3/_box-shadow.scss
@@ -4,7 +4,7 @@
 // @doc on
 
 @import "shared";
-
+@import "../functions";
 
 // The default color for box shadows
 $default-box-shadow-color: #333333 !default;

--- a/lib/compass/css3/_columns.scss
+++ b/lib/compass/css3/_columns.scss
@@ -1,4 +1,5 @@
 @import "shared";
+@import "../functions";
 
 // Specify the shorthand `columns` property.
 //

--- a/lib/compass/css3/_filter.scss
+++ b/lib/compass/css3/_filter.scss
@@ -1,4 +1,5 @@
 @import "shared";
+@import "../functions";
 
 // Provides cross-browser support for the upcoming (?) css3 filter property.
 //

--- a/lib/compass/css3/_text-shadow.scss
+++ b/lib/compass/css3/_text-shadow.scss
@@ -1,4 +1,5 @@
 @import "shared";
+@import "../functions";
 
 // These defaults make the arguments optional for this mixin
 // If you like, set different defaults in your project

--- a/lib/compass/css3/_transition.scss
+++ b/lib/compass/css3/_transition.scss
@@ -1,4 +1,5 @@
 @import "shared";
+@import "../functions";
 
 // CSS Transitions
 // Currently only works in Webkit.


### PR DESCRIPTION
compact function (added in 8d93bef3e9) is used by some files that do not import _lists.scss, where compact() is implemented.
To get compact() work in these files import the function.scss.

Fixes compatibility with libsass > 3.0.1 (where compact was removed) without having
to manually import compass/functions/lists.
