### PR TITLE
Remove -pie prefix from background()

### DIFF
--- a/lib/compass/css3/_images.scss
+++ b/lib/compass/css3/_images.scss
@@ -24,7 +24,7 @@
   @if $experimental-support-for-webkit       and prefixed(-webkit, $backgrounds) {      background: -webkit($backgrounds); }
   @if $experimental-support-for-mozilla      and prefixed(-moz,    $backgrounds) {      background:    -moz($backgrounds); }
   @if $experimental-support-for-opera        and prefixed(-o,      $backgrounds) {      background:      -o($backgrounds); }
-  @if $experimental-support-for-pie          and $add-pie-bg                     { -pie-background:    -pie($backgrounds); }
+  @if $experimental-support-for-pie          and $add-pie-bg                     { -pie-background:         $backgrounds ; }
                                                                                         background:         $backgrounds ;
 }
 

--- a/test/css3/pieSpec.js
+++ b/test/css3/pieSpec.js
@@ -1,0 +1,12 @@
+var render = require('../helper/render');
+var ruleset = require('../helper/ruleset');
+
+describe("Experimentel PIE support", function () {
+
+  it("should not prefix linear-gradient with -pie-", function (done) {
+    render(ruleset('@include background(linear-gradient(to right, white, black));'), function(output, err) {
+      expect(output).toBe(ruleset('background:-owg-linear-gradient(to right, white, black);background:-webkit-linear-gradient(to right, white, black);background:-moz-linear-gradient(to right, white, black);background:-o-linear-gradient(to right, white, black);-pie-background:linear-gradient(to right, white, black);background:linear-gradient(to right, white, black)'));
+      done();
+    }, ['compass/css3/pie', 'compass/css3/images']);
+  });
+});


### PR DESCRIPTION
Input:

``` sass
a {
  @include background(linear-gradient(to right, white, black))
}
```

Output:

``` css
// ...
-pie-background: -pie-linear-gradient(to right, white, black)
// ...
```

Pie does not recognize `linear-gradient` with a `-pie-` prefix.
