### PR TITLE
Only include box-sizing if a value is given

### DIFF
--- a/lib/compass/css3/_box-sizing.scss
+++ b/lib/compass/css3/_box-sizing.scss
@@ -7,7 +7,9 @@
 
 @mixin box-sizing($bs) {
   $bs: unquote($bs);
-  @include experimental(box-sizing, $bs,
-    -moz, -webkit, not(-o), not(-ms), not(-khtml), official
-  );
+  @if $bs != '' {
+    @include experimental(box-sizing, $bs,
+      -moz, -webkit, not(-o), not(-ms), not(-khtml), official
+    );
+  }
 }


### PR DESCRIPTION
Without this I had a small bug using susy and its span mixin:

```scss
@import 'susy';
@import 'compass/css3/box-sizing';

@media (max-width: 720px) {
    .foobar {
        @import span(first to 12);
    }
}
```

```css
@media (max-width: 720px) {
    .foobar {
        -webkit-box-sizing: ;
        -moz-box-sizing: ;
        box-sizing: ;
        width: 100%;
        float: left;
        margin-left: 0;
    }
}
```

Note that this only happens when used within a @media query, not sure how this is related.