### PR TITLE
initialise variable which would otherwise be unavailable in this scope

### DIFF
--- a/lib/compass/functions/_lists.scss
+++ b/lib/compass/functions/_lists.scss
@@ -20,6 +20,8 @@
 // compass_list can't be implemented in sass script
 
 @function -compass-space-list($item1, $item2:null, $item3:null, $item4:null, $item5:null, $item6:null, $item7:null, $item8:null, $item9:null) {
+  $items: null;
+
   // Support for polymorphism.
   @if type-of($item1) == 'list' {
     // Passing a single array of properties.


### PR DESCRIPTION
So I'm not sure why this worked before (maybe because of an outdated lib-sass) but I'm getting a reference error if I don't do this, and that's correct behaviour. In Sass, blocks have their own scope so if you write

```sass
@if true == true {
  $foo: 'bar';
}

@debug($foo);
```

an error will get thrown because `$foo` won't exist in the same scope.