### PR TITLE
Allow setting $experimental-support-for-pie

### DIFF
--- a/lib/compass/css3/_pie.scss
+++ b/lib/compass/css3/_pie.scss
@@ -1,5 +1,3 @@
-$experimental-support-for-pie: true;
-
 // It is recommended that you use Sass's @extend directive to apply the behavior
 // to your PIE elements. To assist you, Compass provides this variable.
 // When set, it will cause the `@include pie` mixin to extend this class.


### PR DESCRIPTION
PIE support couldn't be disabled because this variable was always being overriden by _pie.scss.

Closes: #52