### PR TITLE
Always define compact

### DIFF
--- a/lib/compass/css3/_transition.scss
+++ b/lib/compass/css3/_transition.scss
@@ -176,9 +176,9 @@ $transitionable-prefixed-values: transform, transform-origin !default;
     // Keep a list of delays in case one is specified
     $delays: append($delays, if($delay, $delay, 0s));
 
-    $webkit-value: append($webkit-value, compact(prefixed-for-transition(-webkit, $property) $duration $timing-function));
-       $moz-value: append(   $moz-value, compact(prefixed-for-transition(   -moz, $property) $duration $timing-function $delay));
-         $o-value: append(     $o-value, compact(prefixed-for-transition(     -o, $property) $duration $timing-function $delay));
+    $webkit-value: append($webkit-value, compact((prefixed-for-transition(-webkit, $property) $duration $timing-function)...));
+       $moz-value: append(   $moz-value, compact((prefixed-for-transition(   -moz, $property) $duration $timing-function $delay)...));
+         $o-value: append(     $o-value, compact((prefixed-for-transition(     -o, $property) $duration $timing-function $delay)...));
   }
 
   @if $experimental-support-for-webkit    {       -webkit-transition : $webkit-value;

--- a/lib/compass/functions/_lists.scss
+++ b/lib/compass/functions/_lists.scss
@@ -20,6 +20,7 @@
 // compass_list can't be implemented in sass script
 
 @function -compass-space-list($item1, $item2:null, $item3:null, $item4:null, $item5:null, $item6:null, $item7:null, $item8:null, $item9:null) {
+  $items: ();
   // Support for polymorphism.
   @if type-of($item1) == 'list' {
     // Passing a single array of properties.
@@ -77,14 +78,13 @@
   @return nth($list, 1);
 }
 
-@if not(function-exists(compact)) {
-  @function compact($vars...) {
-    $list: ();
-    @each $var in $vars {
-        @if $var {
-            $list: append($list, $var, comma);
-        }
-    }
-    @return $list;
+@function compact($vars...) {
+  $separator: list-separator($vars);
+  $list: ();
+  @each $var in $vars {
+      @if $var {
+          $list: append($list, $var, $separator);
+      }
   }
+  @return $list;
 }


### PR DESCRIPTION
This implement of compact is functionally equivalent of the
unofficial native one that has been permanently removed from LibSass.
There is no risk in always using this version. The version of LibSass
that had a `compact` function is extremely difficult to obtain, and
is long unsupported.

More importantly defining function inside control structures is not
valid in Sass and produces errors for people using this library.

Fixes #84
Fixes #85