### PR TITLE
Fix hardcoded $experimental-support-for-pie variable

### DIFF
--- a/lib/compass/css3/_pie.scss
+++ b/lib/compass/css3/_pie.scss
@@ -1,4 +1,4 @@
-$experimental-support-for-pie: true;
+$experimental-support-for-pie: true !default;
 
 // It is recommended that you use Sass's @extend directive to apply the behavior
 // to your PIE elements. To assist you, Compass provides this variable.
@@ -38,7 +38,7 @@ $pie-behavior: stylesheet-url("PIE.htc") !default;
 // relative to the stylesheet. It considers them relative
 // to the webpage. As a result, you cannot reliably use
 // compass's relative_assets with PIE.
-// 
+//
 // * `$approach` - one of: relative, z-index, or none
 // * `$z-index` - when using the z-index approach, this
 //                is the z-index that is applied.


### PR DESCRIPTION
The `$experimental-support-for-pie` could not be changed because
we were inadvertently always resetting it. This maintains the default
initial value but will allow it to be changed in userland.

Fixes #52
Closes #81