### PR TITLE
Adds 'rhythm-margins' in typography section

### DIFF
--- a/lib/compass/typography/_vertical_rhythm.scss
+++ b/lib/compass/typography/_vertical_rhythm.scss
@@ -217,3 +217,13 @@ $base-half-leader: $base-leader / 2;
 @mixin h-borders($width: 1px, $lines: 1, $font-size: $base-font-size, $border-style: $default-rhythm-border-style) {
   @include horizontal-borders($width, $lines, $font-size, $border-style);
 }
+
+// Shorthand mixin to apply whitespace for top and bottom margins.
+@mixin rhythm-margins(
+  $leader: 1,
+  $trailer: $leader,
+  $font-size: $base-font-size
+) {
+  @include leader($leader, $font-size);
+  @include trailer($trailer, $font-size);
+}


### PR DESCRIPTION
Added `rhythm-margins` mixin in `typography/_vertical_rhythm.scss` based off of original compass project.
