### PR TITLE
Update _lists.scss

### DIFF
--- a/lib/compass/functions/_lists.scss
+++ b/lib/compass/functions/_lists.scss
@@ -77,14 +77,12 @@
   @return nth($list, 1);
 }
 
-@if not(function-exists(compact)) {
-  @function compact($vars...) {
-    $list: ();
-    @each $var in $vars {
-        @if $var {
-            $list: append($list, $var, comma);
-        }
-    }
-    @return $list;
+@function compact($vars...) {
+  $list: ();
+  @each $var in $vars {
+      @if $var {
+          $list: append($list, $var, comma);
+      }
   }
+  @return $list;
 }


### PR DESCRIPTION
Unless redefining a function will otherwise break things, the conditional definition of function compat breaks compilation with latest node-sass:  "Functions may not be defined within control directives or other mixins." AFAICT, there is no current workaround.