### PR TITLE
Update _box_sizing.scss

### DIFF
--- a/lib/compass/css3/_box-sizing.scss
+++ b/lib/compass/css3/_box-sizing.scss
@@ -1,11 +1,16 @@
 @import "shared";
 
+// The default box-sizing model when no argument is provided to the box-sizing mixin: [ content-box | border-box | padding-box ]
+//
+// The browser default is content-box, compass defaults to border-box.
+$default-box-sizing: border-box !default;
+
 // Change the box model for Mozilla, Webkit, IE8 and the future
 //
 // @param $bs
 //   [ content-box | border-box ]
 
-@mixin box-sizing($bs) {
+@mixin box-sizing($bs: $default-box-sizing) {
   $bs: unquote($bs);
   @include experimental(box-sizing, $bs,
     -moz, -webkit, not(-o), not(-ms), not(-khtml), official


### PR DESCRIPTION
Does not stop on error if mixin is used without parameter.
