### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/compass/functions/_cross_browser_support.scss
+++ b/lib/compass/functions/_cross_browser_support.scss
@@ -9,8 +9,8 @@
   @each $item in $properties {
     @if type-of($item) == 'string' {
       $prefixed: $prefixed or str-index($item, 'url') != 1 and str-index($item, 'rgb') != 1 and str-index($item, '#') != 1;
-    } @elseif type-of($item) == 'color' {
-    } @elseif $item != null {
+    } @else if type-of($item) == 'color' {
+    } @else if $item != null {
       $prefixed: true;
     }
   }


### PR DESCRIPTION
Fix the following deprecation warning :

DEPRECATION WARNING on line 13, column 7 of node_modules/compass-mixins/lib/compass/functions/_cross_browser_support.scss: 
@elseif is deprecated and will not be supported in future Sass versions.
Use "@else if" instead.